### PR TITLE
Missing 'certificate' key in finalize response #42

### DIFF
--- a/automatoes/acme.py
+++ b/automatoes/acme.py
@@ -375,23 +375,6 @@ class AcmeV2(Acme):
             )
         raise AcmeError(response)
 
-    def clean_authorizations(self, order):
-        """
-        If a new order created, all existing authrizations are disabled
-        to prevent from bug #42 by clearing history
-        :param Order order: order to be cleaned
-        :return:
-        """
-        if len(order.contents['authorizations']) == 1:
-            return False
-
-        for auth in order.contents['authorizations']:
-            response = self.post(auth, { 'status': 'deactivated' })
-            if response.status_code != 201:
-                raise AcmeError(response)
-        return True
-
-
     def query_orders(self):
         """ Query existent order status
 
@@ -490,9 +473,7 @@ class AcmeV2(Acme):
                                         kid=self.account.uri)
             iteration_count += 1
 
-        print(_json(response)) # DEBUG
-        if (_json(response)['status'] in ["valid", "ready"] and
-            'certificate' in _json(response)):
+        if _json(response)['status'] in ["valid", "ready"]:
             order.certificate_uri = _json(response)['certificate']
 
         if response.status_code == 200:

--- a/automatoes/acme.py
+++ b/automatoes/acme.py
@@ -458,6 +458,8 @@ class AcmeV2(Acme):
         response = self.post(order.contents['finalize'], {
             'csr': export_certificate_for_acme(csr),
         }, kid=self.account.uri)
+        if _json(response)['status'] == "valid":
+            order.certificate_uri = _json(response)['certificate']
         if response.status_code == 200:
             return _json(response)
         raise AcmeError(response)
@@ -473,7 +475,7 @@ class AcmeV2(Acme):
                                         kid=self.account.uri)
             iteration_count += 1
 
-        if _json(response)['status'] in ["valid", "ready"]:
+        if _json(response)['status'] == "valid":
             order.certificate_uri = _json(response)['certificate']
 
         if response.status_code == 200:

--- a/automatoes/acme.py
+++ b/automatoes/acme.py
@@ -375,6 +375,23 @@ class AcmeV2(Acme):
             )
         raise AcmeError(response)
 
+    def clean_authorizations(self, order):
+        """
+        If a new order created, all existing authrizations are disabled
+        to prevent from bug #42 by clearing history
+        :param Order order: order to be cleaned
+        :return:
+        """
+        if len(order.contents['authorizations']) == 1:
+            return False
+
+        for auth in order.contents['authorizations']:
+            response = self.post(auth, { 'status': 'deactivated' })
+            if response.status_code != 201:
+                raise AcmeError(response)
+        return True
+
+
     def query_orders(self):
         """ Query existent order status
 
@@ -473,7 +490,9 @@ class AcmeV2(Acme):
                                         kid=self.account.uri)
             iteration_count += 1
 
-        if _json(response)['status'] in ["valid", "ready"]:
+        print(_json(response)) # DEBUG
+        if (_json(response)['status'] in ["valid", "ready"] and
+            'certificate' in _json(response)):
             order.certificate_uri = _json(response)['certificate']
 
         if response.status_code == 200:


### PR DESCRIPTION
The issue happened now reproducible and I investigated further:
line 476 in acme:
    if _json(response)['status'] in ["valid", "ready"]:
is definitely wrong, as only "valid" signals the downloadable cert (see page 47 in RFC 8555.

Putting the same code into finalize_order speeds up things even more.

With the 2 patches in my pull request, my software runs perfectly now!
Hopefully this is compatible with acme consumers in automatoes so I can close my fork.
