### PR TITLE
Fix strip_certificates to work with Python 3.11

### DIFF
--- a/automatoes/crypto.py
+++ b/automatoes/crypto.py
@@ -232,7 +232,7 @@ def export_certificate_for_acme(cert):
 
 
 def strip_certificates(data):
-    p = re.compile("-----BEGIN CERTIFICATE-----\n(?s).+?"
+    p = re.compile("(?s)-----BEGIN CERTIFICATE-----\n.+?"
                    "-----END CERTIFICATE-----\n")
     stripped_data = []
     for cert in p.findall(data.decode()):


### PR DESCRIPTION
Python 3.11 only allows global flags at the beginning of regular expressions. Which is different from previous Python versions.