### PR TITLE
Chore/fix maturin ci virtualenv

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Run python unit tests
         run: |
           PYTHONPATH=$PYTHONPATH:. python tests/runtests.py
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.85"
       - name: Build and test Rust backend
         run: |
           maturin build --release

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,6 +34,7 @@ jobs:
           toolchain: "1.85"
       - name: Build and test Rust backend
         run: |
+          pip install maturin
           maturin build --release
           pip install target/wheels/rust_backend-*-cp$(echo "${{ matrix.python-version }}" | tr -d '.')-*.whl
           PYTHONPATH=$PYTHONPATH:. python tests/runrusttests.py

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,7 +30,8 @@ jobs:
           PYTHONPATH=$PYTHONPATH:. python tests/runtests.py
       - name: Build and test Rust backend
         run: |
-          maturin develop --release
+          maturin build --release
+          pip install target/wheels/*.whl
           PYTHONPATH=$PYTHONPATH:. python tests/runrusttests.py
       - name: Run python integration tests
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build and test Rust backend
         run: |
           maturin build --release
-          pip install target/wheels/*.whl
+          pip install target/wheels/rust_backend-*-cp$(echo "${{ matrix.python-version }}" | tr -d '.')-*.whl
           PYTHONPATH=$PYTHONPATH:. python tests/runrusttests.py
       - name: Run python integration tests
         run: |


### PR DESCRIPTION
## Problem

maturin develop --release fails in CI with Couldn't find a virtualenv or conda environment because maturin develop requires an active virtualenv, which isn't present in GitHub Actions (or act) containers.

## Fix

Three changes to .github/workflows/run_tests.yml:

    Replace maturin develop with maturin build + pip install — maturin build produces a wheel, pip installs it directly without needing a virtualenv.
    Add Rust toolchain setup — act containers lack cargo; dtolnay/rust-toolchain@master with toolchain: "1.85" (matches Cargo.toml) ensures both act and real CI work.
    Pin wheel glob to current Python version — avoids a race condition in act where parallel matrix jobs see each other's wheels. Uses cp$(echo "${{ matrix.python-version }}" | tr -d '.') to generate cp311/cp312/etc.

Verification

    maturin build --release + pip install target/wheels/*.whl succeeds locally
    tests/runrusttests.py: 2/2 pass
    act-ephemeral.sh dry-run: all 4 matrix jobs (Python 3.11–3.14) pass — Rust build, install, unit tests, and integration tests (11/11)
